### PR TITLE
Add one more keyword for a Linux target.

### DIFF
--- a/src/minigmp_global.h
+++ b/src/minigmp_global.h
@@ -12,7 +12,7 @@
 #  define MINIGMPSHARED_EXPORT __declspec(dllexport)
 #endif
 
-#if defined (linux) || defined (__APPLE__)
+#if defined (linux) || defined (__linux__) || defined (__APPLE__)
 #  define MINIGMPSHARED_EXPORT __attribute__((visibility("default")))
 #endif
 


### PR DESCRIPTION
GCC 10.2.0 on Manjaro Linux doesn't have "linux" macro, only "__linux" and "\__linux\__".